### PR TITLE
Use cls parameter in NGram class methods

### DIFF
--- a/langdetect/utils/ngram.py
+++ b/langdetect/utils/ngram.py
@@ -54,7 +54,7 @@ class NGram(object):
             if ch < 'A' or ('Z' < ch < 'a') or 'z' < ch:
                 ch = ' '
         elif block == 'Latin-1 Supplement':
-            if NGram.LATIN1_EXCLUDED.find(ch) >= 0:
+            if cls.LATIN1_EXCLUDED.find(ch) >= 0:
                 ch = ' '
         elif block == 'Latin Extended-B':
             # normalization for Romanian
@@ -77,7 +77,7 @@ class NGram(object):
         elif block == 'Bopomofo' or block == 'Bopomofo Extended':
             ch = six.u('\u3105')
         elif block == 'CJK Unified Ideographs':
-            ch = NGram.CJK_MAP.get(ch, ch)
+            ch = cls.CJK_MAP.get(ch, ch)
         elif block == 'Hangul Syllables':
             ch = six.u('\uac00')
         return ch
@@ -88,10 +88,10 @@ class NGram(object):
         Normalize Alphabet + Diacritical Mark(U+03xx) into U+1Exx.
         '''
         def repl(m):
-            alphabet = NGram.TO_NORMALIZE_VI_CHARS.find(m.group(1))
-            dmark = NGram.DMARK_CLASS.find(m.group(2))  # Diacritical Mark
-            return NGram.NORMALIZED_VI_CHARS[dmark][alphabet]
-        return NGram.ALPHABET_WITH_DMARK.sub(repl, text)
+            alphabet = cls.TO_NORMALIZE_VI_CHARS.find(m.group(1))
+            dmark = cls.DMARK_CLASS.find(m.group(2))  # Diacritical Mark
+            return cls.NORMALIZED_VI_CHARS[dmark][alphabet]
+        return cls.ALPHABET_WITH_DMARK.sub(repl, text)
 
     NORMALIZED_VI_CHARS = [
         messages.get_string('NORMALIZED_VI_CHARS_0300'),
@@ -238,9 +238,9 @@ class NGram(object):
 
     @classmethod
     def _init_cjk_map(cls):
-        for cjk_list in NGram.CJK_CLASS:
+        for cjk_list in cls.CJK_CLASS:
             representative = cjk_list[0]
             for ch in cjk_list:
-                NGram.CJK_MAP[ch] = representative
+                cls.CJK_MAP[ch] = representative
 
 NGram._init_cjk_map()


### PR DESCRIPTION
Use the cls class parameter passed to the NGram class methods. This
parameter is the only reason to mark something a class method, and it
should be used if so marked.

This change also provides a small but consistent speed-up due to using a
local rather than a global variable, with the normalize function on a
critical path.