### PR TITLE
[Fix multithreading problem]

### DIFF
--- a/langdetect/detector_factory.py
+++ b/langdetect/detector_factory.py
@@ -11,6 +11,8 @@ from .detector import Detector
 from .lang_detect_exception import ErrorCode, LangDetectException
 from .utils.lang_profile import LangProfile
 
+PROFILES_DIRECTORY = path.join(path.dirname(__file__), 'profiles')
+_factory = None
 
 class DetectorFactory(object):
     '''
@@ -31,6 +33,7 @@ class DetectorFactory(object):
     def __init__(self):
         self.word_lang_prob_map = {}
         self.langlist = []
+        self.load_profile(PROFILES_DIRECTORY)
 
     def load_profile(self, profile_directory):
         list_files = os.listdir(profile_directory)
@@ -114,14 +117,10 @@ class DetectorFactory(object):
         return list(self.langlist)
 
 
-PROFILES_DIRECTORY = path.join(path.dirname(__file__), 'profiles')
-_factory = None
-
 def init_factory():
     global _factory
     if _factory is None:
         _factory = DetectorFactory()
-        _factory.load_profile(PROFILES_DIRECTORY)
 
 def detect(text):
     init_factory()


### PR DESCRIPTION
Profiles are now loaded as soon as the object is created.

Before, this was done in two steps, creating a race condition on the
global variable _factory: as soon as the line '_factory =
DetectorFactory()' was executed, the other threads jumped the condition
'if _factory is None' going through 'create' and '_create_detector',
until they met the line 'if not self.langlist'.

Since the thread that created the global DetectorFactory didn't
necessarily have the time to populate the language profiles, the other
threads start raising LangDetectException until the langlist is no
longer empty (which is not good either: it can have just one language...).

Since the global variable is used to avoid reloading the profiles again
and again (which can take some time), I'm leaving it global, but the
profile loading process must therefore be done as soon as the object is
created, so when the other threads detect that '_factory' is loaded,
it's really going to be loaded (not partially loaded). :)

Fix #30 