### PR TITLE
[Fix #30] Fix multithread race condition on global variable _factory

### DIFF
--- a/langdetect/detector_factory.py
+++ b/langdetect/detector_factory.py
@@ -11,6 +11,8 @@ from .detector import Detector
 from .lang_detect_exception import ErrorCode, LangDetectException
 from .utils.lang_profile import LangProfile
 
+from threading import Lock
+
 
 class DetectorFactory(object):
     '''
@@ -116,12 +118,16 @@ class DetectorFactory(object):
 
 PROFILES_DIRECTORY = path.join(path.dirname(__file__), 'profiles')
 _factory = None
+factory_lock = Lock()
+
 
 def init_factory():
     global _factory
-    if _factory is None:
-        _factory = DetectorFactory()
-        _factory.load_profile(PROFILES_DIRECTORY)
+    with factory_lock:
+        if _factory is None:
+            _factory = DetectorFactory()
+            _factory.load_profile(PROFILES_DIRECTORY)
+
 
 def detect(text):
     init_factory()


### PR DESCRIPTION
A lock is used to avoid a race condition on the global variable _factory: as soon as the line '_factory = DetectorFactory()' was executed, the other threads jumped the condition 'if _factory is None' going through 'create' and '_create_detector', until they meet the line 'if not self.langlist'.

Since the thread that created the global DetectorFactory didn't necessarily have the time to populate the language profiles, the other threads start raising LangDetectException until the langlist is no longer empty (which is not good either: it can have just one language...).

Since the global variable is used to avoid reloading the profiles again and again (which can take some time), I'm leaving it global, but a lock is used to ensure that other threads can use the fully loaded object, instead of a yet-to-populate langlist.